### PR TITLE
Add body getter and support multipart/form-data enctype

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,20 @@ npm install koa-methodoverride
 var app = require('koa')();
 var methodOverride = require('koa-methodoverride');
 
-app.use(methodOverride());
+app.use(methodOverride('_method'));
 
 app.listen(3000);
+```
+
+This package leverages [async-busboy](https://github.com/m4nuC/async-busboy) for `multipart/formdata` enctype.  
+For those who want to read files and fields in this case, a new helper method `ctx.req.getAsyncBusboyBody()` is exposed.
+Thus, instead of
+```js
+const { files, fields } = await asyncBusboy(ctx.req);
+```
+, you need to use
+```js
+const { files, fields } = await ctx.req.getAsyncBusboyBody();
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function createQueryOrBodyGetter(key) {
   return queryOrBodyGetter
 
   function queryOrBodyGetter(req) {
-    return req.query[key] || req.body[key]
+    return req.query[key] || (req.body && req.body[key])
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,9 +16,12 @@
 
 const debug = require('debug')('method-override')
 const methods = require('methods')
+const asyncBusboy = require('async-busboy')
 
 const ALLOWED_METHODS = 'POST'
 const HTTP_METHOD_OVERRIDE_HEADER = "X-HTTP-Method-Override"
+
+let asyncBusboyBody = null
 
 /**
  * Method Override:
@@ -57,7 +60,7 @@ function methodOverride(getter, options) {
     ? ALLOWED_METHODS.split(' ')
     : options.methods
 
-  return (ctx, next) => {
+  return async (ctx, next) => {
     const req = ctx.request
     let method
     let val
@@ -69,7 +72,10 @@ function methodOverride(getter, options) {
       return next()
     }
 
-    val = get(req, ctx.response)
+    asyncBusboyBody = null
+    ctx.req.getAsyncBusboyBody = async () => (asyncBusboyBody || await asyncBusboy(ctx.req))
+
+    val = await get(req, ctx.response, ctx.req)
     method = Array.isArray(val) ? val[0] : val
 
     // replace
@@ -102,8 +108,15 @@ function createGetter(str) {
 function createQueryOrBodyGetter(key) {
   return queryOrBodyGetter
 
-  function queryOrBodyGetter(req) {
-    return req.query[key] || (req.body && req.body[key])
+  async function queryOrBodyGetter(req, ...args) {
+    const method = req.query[key] || (req.body && req.body[key])
+    if (method) {
+      return method
+    } else {
+      const koaReq = args[1]
+      asyncBusboyBody = await asyncBusboy(koaReq)
+      return asyncBusboyBody.fields[key]
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -92,18 +92,18 @@ function createGetter(str) {
     return createHeaderGetter(str)
   }
 
-  return createQueryGetter(str)
+  return createQueryOrBodyGetter(str)
 }
 
 /**
- * Create a getter for the given query key name.
+ * Create a getter for the given query or body key name.
  */
 
-function createQueryGetter(key) {
-  return queryGetter
+function createQueryOrBodyGetter(key) {
+  return queryOrBodyGetter
 
-  function queryGetter(req) {
-    return req.query[key]
+  function queryOrBodyGetter(req) {
+    return req.query[key] || req.body[key]
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "middleware"
   ],
   "dependencies": {
+    "async-busboy": "^0.3.3",
     "debug": "*",
     "methods": "*"
   },


### PR DESCRIPTION
This PR supports `req.body` getter. E.g. I was using [jquery-ujs](https://github.com/rails/jquery-ujs) for an anchor tag with `data-method="delete"`. Since jquery-ujs is originally designed for rails, it used form body to send hidden input field value with name of `_method`. And this obviously doesn't get passed query getter.